### PR TITLE
Port key handling to 1.7.10 and add Forge mod class

### DIFF
--- a/common/src/main/java/pro/mikey/xray/XRay.java
+++ b/common/src/main/java/pro/mikey/xray/XRay.java
@@ -1,12 +1,13 @@
 package pro.mikey.xray;
 
-import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.resources.ResourceLocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.lwjgl.glfw.GLFW;
+import org.lwjgl.input.Keyboard;
+import cpw.mods.fml.client.registry.ClientRegistry;
 import pro.mikey.xray.screens.ScanManageScreen;
 import pro.mikey.xray.utils.XPlatShim;
 import pro.mikey.xray.core.ScanController;
@@ -19,13 +20,15 @@ public enum XRay {
 	public static final String MOD_ID = "xray";
 	private static final Logger LOGGER = LogManager.getLogger();
 
-	public static final XPlatShim XPLAT = ServiceLoader.load(XPlatShim.class).findFirst().orElseThrow();
+        public static final XPlatShim XPLAT = ServiceLoader.load(XPlatShim.class).findFirst().orElseThrow();
 
-	public static final KeyMapping TOGGLE_KEY = new KeyMapping(I18n.get("xray.config.toggle"), GLFW.GLFW_KEY_BACKSLASH, "xray.mod_name");
-	public static final KeyMapping OPEN_GUI_KEY = new KeyMapping(I18n.get("xray.config.open"), GLFW.GLFW_KEY_G, "xray.mod_name");
+        public static final KeyBinding TOGGLE_KEY = new KeyBinding(I18n.get("xray.config.toggle"), Keyboard.KEY_BACKSLASH, "xray.mod_name");
+        public static final KeyBinding OPEN_GUI_KEY = new KeyBinding(I18n.get("xray.config.open"), Keyboard.KEY_G, "xray.mod_name");
 
-	public void init() {
-	}
+        public void init() {
+                ClientRegistry.registerKeyBinding(TOGGLE_KEY);
+                ClientRegistry.registerKeyBinding(OPEN_GUI_KEY);
+        }
 
 	public void onToggleKeyPressed() {
 		if (minecraftNotReady()) {

--- a/common/src/main/java/pro/mikey/xray/core/ScanController.java
+++ b/common/src/main/java/pro/mikey/xray/core/ScanController.java
@@ -2,7 +2,7 @@ package pro.mikey.xray.core;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
@@ -78,11 +78,11 @@ public enum ScanController {
             requestBlockFinder(true); // finally, force a refresh
 
             if (!XRay.config().showOverlay.get() && Minecraft.getInstance().player != null)
-                Minecraft.getInstance().player.displayClientMessage(Component.translatable("xray.toggle.activated"), false);
+                Minecraft.getInstance().player.displayClientMessage(new ChatComponentTranslation("xray.toggle.activated"), false);
         } else // disable drawing
         {
             if (!XRay.config().showOverlay.get() && Minecraft.getInstance().player != null)
-                Minecraft.getInstance().player.displayClientMessage(Component.translatable("xray.toggle.deactivated"), false);
+                Minecraft.getInstance().player.displayClientMessage(new ChatComponentTranslation("xray.toggle.deactivated"), false);
 
             xrayActive = false;
         }

--- a/common/src/main/java/pro/mikey/xray/screens/FindBlockScreen.java
+++ b/common/src/main/java/pro/mikey/xray/screens/FindBlockScreen.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.ObjectSelectionList;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.Nullable;
@@ -36,7 +37,7 @@ public class FindBlockScreen extends GuiBase {
         search.setFocused(true);
         this.setFocused(search);
 
-        addRenderableWidget(Button.builder(Component.translatable("xray.single.cancel"), b -> Minecraft.getInstance().setScreen(new ScanManageScreen()))
+        addRenderableWidget(Button.builder(new ChatComponentTranslation("xray.single.cancel"), b -> Minecraft.getInstance().setScreen(new ScanManageScreen()))
                 .pos(getWidth() / 2 + 43, getHeight() / 2 + 84)
                 .size(60, 20)
                 .build());

--- a/common/src/main/java/pro/mikey/xray/screens/HelpScreen.java
+++ b/common/src/main/java/pro/mikey/xray/screens/HelpScreen.java
@@ -5,6 +5,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.resources.ResourceLocation;
 import pro.mikey.xray.screens.helpers.GuiBase;
 
@@ -28,7 +29,7 @@ public class HelpScreen extends GuiBase {
         areas.add(new LinedText("xray.message.help.gui"));
         areas.add(new LinedText("xray.message.help.warning"));
 
-        this.addRenderableWidget(Button.builder(Component.translatable("xray.single.close"), btn -> Minecraft.getInstance().setScreen(new ScanManageScreen()))
+        this.addRenderableWidget(Button.builder(new ChatComponentTranslation("xray.single.close"), btn -> Minecraft.getInstance().setScreen(new ScanManageScreen()))
             .pos((getWidth() / 2) - 100, (getHeight() / 2) + 80)
             .size(200, 20)
             .build()

--- a/common/src/main/java/pro/mikey/xray/screens/ScanConfigureScreen.java
+++ b/common/src/main/java/pro/mikey/xray/screens/ScanConfigureScreen.java
@@ -9,6 +9,7 @@ import net.minecraft.client.gui.layouts.GridLayout;
 import net.minecraft.client.gui.layouts.Layout;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
@@ -80,11 +81,11 @@ public class ScanConfigureScreen extends GuiBase {
                 .size(20, 20)
                 .build());
 
-        rowHelper.addChild(Button.builder(Component.translatable("xray.single.cancel"), b -> Minecraft.getInstance().setScreen(this.previousScreenCallback.get()))
+        rowHelper.addChild(Button.builder(new ChatComponentTranslation("xray.single.cancel"), b -> Minecraft.getInstance().setScreen(this.previousScreenCallback.get()))
                 .size(60, 20)
                 .build());
 
-        rowHelper.addChild(Button.builder(Component.translatable(editingType != null ? "xray.title.edit" : "xray.single.add"), b -> {
+        rowHelper.addChild(Button.builder(new ChatComponentTranslation(editingType != null ? "xray.title.edit" : "xray.single.add"), b -> {
                             if (editingType != null) {
                                 editBlock();
                             } else {

--- a/common/src/main/java/pro/mikey/xray/screens/ScanManageScreen.java
+++ b/common/src/main/java/pro/mikey/xray/screens/ScanManageScreen.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
@@ -77,16 +78,16 @@ public class ScanManageScreen extends GuiBase {
         addRenderableWidget(this.search);
 
         // side bar buttons
-        addRenderableWidget(new SupportButtonInner((getWidth() / 2) + 79, getHeight() / 2 - 60, 120, 20, Component.translatable("xray.input.add"), "xray.tooltips.add_block", button -> {
+        addRenderableWidget(new SupportButtonInner((getWidth() / 2) + 79, getHeight() / 2 - 60, 120, 20, new ChatComponentTranslation("xray.input.add"), "xray.tooltips.add_block", button -> {
             minecraft.setScreen(new FindBlockScreen());
         }));
 
-        addRenderableWidget(new SupportButtonInner(getWidth() / 2 + 79, getHeight() / 2 - 38, 120, 20, Component.translatable("xray.input.add_hand"), "xray.tooltips.add_block_in_hand", button -> {
+        addRenderableWidget(new SupportButtonInner(getWidth() / 2 + 79, getHeight() / 2 - 38, 120, 20, new ChatComponentTranslation("xray.input.add_hand"), "xray.tooltips.add_block_in_hand", button -> {
             ItemStack handItem = minecraft.player.getItemInHand(InteractionHand.MAIN_HAND);
 
             // Check if the hand item is a block or not
             if (!(handItem.getItem() instanceof BlockItem)) {
-                minecraft.player.displayClientMessage(Component.literal("[XRay] " + Component.translatable("xray.message.invalid_hand", Utils.safeItemStackName(handItem).getString())), false);
+                minecraft.player.displayClientMessage(Component.literal("[XRay] " + new ChatComponentTranslation("xray.message.invalid_hand", Utils.safeItemStackName(handItem).getString())), false);
                 this.onClose();
                 return;
             }
@@ -94,7 +95,7 @@ public class ScanManageScreen extends GuiBase {
             minecraft.setScreen(new ScanConfigureScreen(((BlockItem) handItem.getItem()).getBlock(), ScanManageScreen::new));
         }));
 
-        addRenderableWidget(new SupportButtonInner(getWidth() / 2 + 79, getHeight() / 2 - 16, 120, 20, Component.translatable("xray.input.add_look"), "xray.tooltips.add_block_looking_at", button -> {
+        addRenderableWidget(new SupportButtonInner(getWidth() / 2 + 79, getHeight() / 2 - 16, 120, 20, new ChatComponentTranslation("xray.input.add_look"), "xray.tooltips.add_block_looking_at", button -> {
             Player player = minecraft.player;
             if (minecraft.level == null || player == null) {
                 return;
@@ -122,18 +123,18 @@ public class ScanManageScreen extends GuiBase {
             }
         }));
 
-        addRenderableWidget(distButtons = new SupportButtonInner((getWidth() / 2) + 79, getHeight() / 2 + 6, 120, 20, Component.translatable("xray.input.show-lava", ScanController.INSTANCE.isLavaActive()), "xray.tooltips.show_lava", button -> {
+        addRenderableWidget(distButtons = new SupportButtonInner((getWidth() / 2) + 79, getHeight() / 2 + 6, 120, 20, new ChatComponentTranslation("xray.input.show-lava", ScanController.INSTANCE.isLavaActive()), "xray.tooltips.show_lava", button -> {
             ScanController.INSTANCE.toggleLava();
-            button.setMessage(Component.translatable("xray.input.show-lava", ScanController.INSTANCE.isLavaActive()));
+            button.setMessage(new ChatComponentTranslation("xray.input.show-lava", ScanController.INSTANCE.isLavaActive()));
         }));
 
-        addRenderableWidget(distButtons = new SupportButtonInner((getWidth() / 2) + 79, getHeight() / 2 + 36, 120, 20, Component.translatable("xray.input.distance", ScanController.INSTANCE.getVisualRadius()), "xray.tooltips.distance", button -> {
+        addRenderableWidget(distButtons = new SupportButtonInner((getWidth() / 2) + 79, getHeight() / 2 + 36, 120, 20, new ChatComponentTranslation("xray.input.distance", ScanController.INSTANCE.getVisualRadius()), "xray.tooltips.distance", button -> {
             ScanController.INSTANCE.incrementCurrentDist();
-            button.setMessage(Component.translatable("xray.input.distance", ScanController.INSTANCE.getVisualRadius()));
+            button.setMessage(new ChatComponentTranslation("xray.input.distance", ScanController.INSTANCE.getVisualRadius()));
         }));
 
         addRenderableWidget(
-            Button.builder(Component.translatable("xray.single.help"), button -> {
+            Button.builder(new ChatComponentTranslation("xray.single.help"), button -> {
                 minecraft.setScreen(new HelpScreen());
             })
                     .pos(getWidth() / 2 + 79, getHeight() / 2 + 58)
@@ -142,7 +143,7 @@ public class ScanManageScreen extends GuiBase {
         );
 
         addRenderableWidget(
-                Button.builder(Component.translatable("xray.single.close"), button -> {
+                Button.builder(new ChatComponentTranslation("xray.single.close"), button -> {
                     this.onClose();
                 })
                         .pos((getWidth() / 2 + 79) + 62, getHeight() / 2 + 58)
@@ -184,7 +185,7 @@ public class ScanManageScreen extends GuiBase {
 
         if (mouse == 1 && distButtons.isMouseOver(x, y)) {
             ScanController.INSTANCE.decrementCurrentDist();
-            distButtons.setMessage(Component.translatable("xray.input.distance", ScanController.INSTANCE.getVisualRadius()));
+            distButtons.setMessage(new ChatComponentTranslation("xray.input.distance", ScanController.INSTANCE.getVisualRadius()));
             distButtons.playDownSound(Minecraft.getInstance().getSoundManager());
         }
 
@@ -201,9 +202,9 @@ public class ScanManageScreen extends GuiBase {
         pose.pushMatrix();
         pose.translate(this.getWidth() / 2f - 140, ((this.getHeight() / 2f) - 3) + 120);
         pose.scale(0.75f, 0.75f);
-        graphics.drawString(this.font, Component.translatable("xray.tooltips.edit1"), 0, 0, Color.GRAY.getRGB());
+        graphics.drawString(this.font, new ChatComponentTranslation("xray.tooltips.edit1"), 0, 0, Color.GRAY.getRGB());
         pose.translate(0, 12);
-        graphics.drawString(this.font, Component.translatable("xray.tooltips.edit2"), 0, 0, Color.GRAY.getRGB());
+        graphics.drawString(this.font, new ChatComponentTranslation("xray.tooltips.edit2"), 0, 0, Color.GRAY.getRGB());
         pose.popMatrix();
     }
 
@@ -215,7 +216,7 @@ public class ScanManageScreen extends GuiBase {
 
     static final class SupportButtonInner extends SupportButton {
         public SupportButtonInner(int widthIn, int heightIn, int width, int height, Component text, String i18nKey, OnPress onPress) {
-            super(widthIn, heightIn, width, height, text, Component.translatable(i18nKey), onPress);
+            super(widthIn, heightIn, width, height, text, new ChatComponentTranslation(i18nKey), onPress);
         }
     }
 

--- a/common/src/main/java/pro/mikey/xray/screens/helpers/SliderWidget.java
+++ b/common/src/main/java/pro/mikey/xray/screens/helpers/SliderWidget.java
@@ -2,18 +2,19 @@ package pro.mikey.xray.screens.helpers;
 
 import net.minecraft.client.gui.components.AbstractSliderButton;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.ChatComponentTranslation;
 
 public class SliderWidget extends AbstractSliderButton {
     private final String messageKey;
 
     public SliderWidget(int x, int y, int width, int height, String messageKey, double initialValue) {
-        super(x, y, width, height, Component.translatable(messageKey, (int) (initialValue * 255)), initialValue);
+        super(x, y, width, height, new ChatComponentTranslation(messageKey, (int) (initialValue * 255)), initialValue);
         this.messageKey = messageKey;
     }
 
     @Override
     protected void updateMessage() {
-        this.setMessage(Component.translatable(messageKey, (int) (this.value * 255)));
+        this.setMessage(new ChatComponentTranslation(messageKey, (int) (this.value * 255)));
     }
 
     @Override

--- a/common/src/main/java/pro/mikey/xray/utils/Utils.java
+++ b/common/src/main/java/pro/mikey/xray/utils/Utils.java
@@ -1,6 +1,8 @@
 package pro.mikey.xray.utils;
 
-import net.minecraft.network.chat.Component;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -9,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
  * Miscellaneous utility methods for the mod
  */
 public class Utils {
-    public static Component safeItemStackName(ItemStack stack) {
+    public static IChatComponent safeItemStackName(ItemStack stack) {
         try {
             @Nullable var hoverName = stack.getHoverName();
             if (hoverName != null) {
@@ -21,9 +23,9 @@ public class Utils {
                 return displayName;
             }
 
-            return Component.translatable(stack.getItem().getDescriptionId());
+            return new ChatComponentTranslation(stack.getItem().getDescriptionId());
         } catch (Exception e) {
-            return Component.literal("Unknown...");
+            return new ChatComponentText("Unknown...");
         }
     }
 }

--- a/forge1710/src/main/java/pro/mikey/xray/XRayForge1710.java
+++ b/forge1710/src/main/java/pro/mikey/xray/XRayForge1710.java
@@ -1,0 +1,55 @@
+package pro.mikey.xray;
+
+import cpw.mods.fml.common.Mod;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
+import cpw.mods.fml.common.gameevent.InputEvent;
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.client.registry.ClientRegistry;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraft.client.Minecraft;
+import pro.mikey.xray.core.ScanController;
+import pro.mikey.xray.core.OutlineRender;
+
+@Mod(modid = XRay.MOD_ID)
+public class XRayForge1710 {
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event) {
+        XRay.INSTANCE.init();
+        ClientRegistry.registerKeyBinding(XRay.TOGGLE_KEY);
+        ClientRegistry.registerKeyBinding(XRay.OPEN_GUI_KEY);
+        FMLCommonHandler.instance().bus().register(this);
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase == TickEvent.Phase.END) {
+            Minecraft mc = Minecraft.getMinecraft();
+            if (mc.thePlayer != null && mc.theWorld != null) {
+                ScanController.INSTANCE.requestBlockFinder(false);
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onRenderWorldLast(RenderWorldLastEvent event) {
+        OutlineRender.renderBlocks(null);
+    }
+
+    @SubscribeEvent
+    public void onKeyInput(InputEvent.KeyInputEvent event) {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.thePlayer == null || mc.currentScreen != null || mc.theWorld == null) {
+            return;
+        }
+        while (XRay.TOGGLE_KEY.isPressed()) {
+            XRay.INSTANCE.onToggleKeyPressed();
+        }
+        while (XRay.OPEN_GUI_KEY.isPressed()) {
+            XRay.INSTANCE.onOpenGuiKeyPressed();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace modern KeyMapping with legacy KeyBinding and register bindings
- Swap Component.translatable usages for ChatComponentTranslation/ChatComponentText
- Add Forge 1.7.10 mod entry class with event handlers and key input processing

## Testing
- `./gradlew build` *(fails: Could not find net.minecraftforge.gradle:ForgeGradle:1.2-1.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_68aec9eea1e0832a95b1eae27bc6abff